### PR TITLE
fix cluster roles for Openshift cluster

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -348,3 +348,33 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - sources.triggermesh.io
+  resources:
+  - awscloudwatchlogssources/finalizers
+  - awscloudwatchsources/finalizers
+  - awscodecommitsources/finalizers
+  - awscognitoidentitysources/finalizers
+  - awscognitouserpoolsources/finalizers
+  - awsdynamodbsources/finalizers
+  - awskinesissources/finalizers
+  - awsperformanceinsightssources/finalizers
+  - awss3sources/finalizers
+  - awssnssources/finalizers
+  - awssqssources/finalizers
+  - azureactivitylogssources/finalizers
+  - azureblobstoragesources/finalizers
+  - azureeventgridsources/finalizers
+  - azureeventhubsources/finalizers
+  - azureiothubsources/finalizers
+  - azurequeuestoragesources/finalizers
+  - azureservicebusqueuesources/finalizers
+  - azureservicebustopicsources/finalizers
+  - googlecloudauditlogssources/finalizers
+  - googlecloudbillingsources/finalizers
+  - googlecloudiotsources/finalizers
+  - googlecloudpubsubsources/finalizers
+  - googlecloudsourcerepositoriessources/finalizers
+  - googlecloudstoragesources/finalizers
+  verbs:
+  - update


### PR DESCRIPTION
Environment: Openshift on Vsphere
Server Version: 4.10.5
Kubernetes Version: v1.23.3+e419edf
knative version: 1.6

Problem: The aws-codeCommit-source is unable to register eventTypes because RBAC issues, because of [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) enforced by admission controllers.

```
{
  "level": "error",
  "ts": "2022-08-17T21:48:19.408Z",
  "logger": "controller",
  "caller": "duck/duck.go:131",
  "msg": "Error creating eventType",
  "commit": "0eb566a",
  "knative.dev/pod": "eventing-controller-5578b47444-p8vb7",
  "knative.dev/traceid": "26621b03-637e-4ed5-a897-2594ef59010c",
  "knative.dev/key": "cnr-demo/source",
  "eventType": {
    "metadata": {
      "name": "fb544041f322d36015b0a2ae929aa418",
      "namespace": "cnr-demo",
      "creationTimestamp": null,
      "labels": { "eventing.knative.dev/sourceName": "source" },
      "ownerReferences": [
        {
          "apiVersion": "sources.triggermesh.io/v1alpha1",
          "kind": "AWSCodeCommitSource",
          "name": "source",
          "uid": "af4bd0c5-8516-410d-8223-eeaf8e5cd6b7",
          "controller": true,
          "blockOwnerDeletion": true
        }
      ]
    },
    "spec": {
      "type": "com.amazon.codecommit.push",
      "source": "<REDACTED>",
      "broker": "broker"
    },
    "status": {}
  },
  "stacktrace": "knative.dev/eventing/pkg/reconciler/source/duck.(*Reconciler).reconcileEventTypes\n\tknative.dev/eventing/pkg/reconciler/source/duck/duck.go:131\nknative.dev/eventing/pkg/reconciler/source/duck.(*Reconciler).reconcile\n\tknative.dev/eventing/pkg/reconciler/source/duck/duck.go:99\nknative.dev/eventing/pkg/reconciler/source/duck.(*Reconciler).Reconcile\n\tknative.dev/eventing/pkg/reconciler/source/duck/duck.go:94\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20220705130606-e60d250dc637/controller/controller.go:542\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20220705130606-e60d250dc637/controller/controller.go:491"
}
```

```
{
  "level": "error",
  "ts": "2022-08-17T21:48:19.409Z",
  "logger": "controller",
  "caller": "controller/controller.go:566",
  "msg": "Reconcile error",
  "commit": "0eb566a",
  "knative.dev/pod": "eventing-controller-5578b47444-p8vb7",
  "knative.dev/traceid": "26621b03-637e-4ed5-a897-2594ef59010c",
  "knative.dev/key": "cnr-demo/source",
  "duration": 0.056732303,
  "error": "eventtypes.eventing.knative.dev \"fb544041f322d36015b0a2ae929aa418\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>",
  "stacktrace": "knative.dev/pkg/controller.(*Impl).handleErr\n\tknative.dev/pkg@v0.0.0-20220705130606-e60d250dc637/controller/controller.go:566\nknative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tknative.dev/pkg@v0.0.0-20220705130606-e60d250dc637/controller/controller.go:543\nknative.dev/pkg/controller.(*Impl).RunContext.func3\n\tknative.dev/pkg@v0.0.0-20220705130606-e60d250dc637/controller/controller.go:491"
}
```

## Proposed Changes
Update finalizers subresource for namespaces